### PR TITLE
feat: draft versioning system for Writing Notebookfeat: draft versioning system — multi-draft per chapter, manuscript i…

### DIFF
--- a/app/dashboard/writing-notebook/page.tsx
+++ b/app/dashboard/writing-notebook/page.tsx
@@ -4,12 +4,14 @@ import { useSession } from 'next-auth/react'
 import { WritingOnboarding } from './WritingOnboarding'
 import { useWorkbook } from './useWorkbook'
 import { useBooks } from '@/hooks/useBooks'
+import { parseManuscriptIntoChapters, type ParsedChapter } from '@/lib/parseManuscript'
 
 // ── Desktop components (new layout) ──────────────────────────────────
 import { WritingNotebookTopBar } from '@/components/writing-notebook/WritingNotebookTopBar'
 import { SidebarNav } from '@/components/writing-notebook/SidebarNav'
 import { InlineAIPanel } from '@/components/writing-notebook/InlineAIPanel'
 import { EditorArea } from '@/components/writing-notebook/EditorArea'
+import { ImportPreviewModal } from '@/components/writing-notebook/ImportPreviewModal'
 
 // ── Mobile components (kept from previous layout) ─────────────────────
 import { NotebookPane } from '@/components/writing-notebook/NotebookPane'
@@ -41,6 +43,9 @@ export default function WritingNotebookPage() {
   const [storySoFarStatus, setStorySoFarStatus] = useState<'upToDate' | 'updating'>('upToDate')
   const [toast, setToast] = useState<string | null>(null)
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null)
+
+  // ── Import state ───────────────────────────────────────────────────
+  const [importChapters, setImportChapters] = useState<ParsedChapter[] | null>(null)
 
   // ── Mobile state ───────────────────────────────────────────────────
   const [phase, setPhase] = useState<NotebookPhase>('setup')
@@ -86,7 +91,7 @@ export default function WritingNotebookPage() {
     const meta = workbook.getChapterMeta('writing')
     const chapters = Array.from({ length: meta.count }, (_, i) => ({
       title: meta.titles[i] ?? '',
-      content: workbook.getValue('writing', 'chapter', i),
+      content: workbook.getActiveDraftContent(i),
       order: i,
     })).filter(c => c.content.trim())
 
@@ -117,7 +122,7 @@ export default function WritingNotebookPage() {
     if (currentSummary.trim()) return // already populated
     const meta = workbook.getChapterMeta('writing')
     const hasContent = Array.from({ length: meta.count }, (_, i) =>
-      workbook.getValue('writing', 'chapter', i)
+      workbook.getActiveDraftContent(i)
     ).some(c => c.trim())
     if (hasContent) {
       didLoadTriggerRef.current = true
@@ -189,6 +194,66 @@ export default function WritingNotebookPage() {
     workbook.setValue('writing', 'chapter', content, chapterIndex)
   }, [workbook])
 
+  // ── Manuscript import flow ─────────────────────────────────────────
+  const handleFileImport = useCallback((file: File) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const text = reader.result as string
+      const parsed = parseManuscriptIntoChapters(text)
+      if (parsed.length === 0) {
+        setToast('Could not detect chapters — make sure your file uses # Chapter headers')
+        setTimeout(() => setToast(null), 4000)
+        return
+      }
+      setImportChapters(parsed)
+    }
+    reader.readAsText(file)
+  }, [])
+
+  const handleImportConfirm = useCallback(() => {
+    if (!importChapters) return
+    const meta = workbook.getChapterMeta('writing')
+
+    for (const ch of importChapters) {
+      const idx = ch.chapterNumber - 1
+      const existing = workbook.getChapterDraftMeta(idx)
+      const newDraftIdx = existing.draftCount
+      // Save imported content as a new draft
+      workbook.setChapterDraft(idx, newDraftIdx, ch.content)
+      // Update draft meta — switch to the new draft
+      workbook.setChapterDraftMeta(idx, {
+        draftCount: newDraftIdx + 1,
+        activeDraft: newDraftIdx,
+      })
+      // Update chapter title if import has one and existing is empty
+      if (ch.title && !(meta.titles[idx]?.trim())) {
+        const titles = [...meta.titles]
+        while (titles.length <= idx) titles.push('')
+        titles[idx] = ch.title
+        workbook.setChapterMeta('writing', { ...workbook.getChapterMeta('writing'), titles })
+      }
+    }
+
+    // Extend chapter count if import added new chapters
+    const maxImportIdx = Math.max(...importChapters.map(c => c.chapterNumber - 1))
+    if (maxImportIdx >= meta.count) {
+      const titles = [...workbook.getChapterMeta('writing').titles]
+      while (titles.length <= maxImportIdx) titles.push('')
+      for (const ch of importChapters) {
+        if (ch.chapterNumber - 1 >= meta.count && ch.title) {
+          titles[ch.chapterNumber - 1] = ch.title
+        }
+      }
+      workbook.setChapterMeta('writing', { count: maxImportIdx + 1, titles })
+    }
+
+    setImportChapters(null)
+    setActiveNavItem('chapter:0')
+    triggerStorySoFarUpdate()
+    setToast(`${importChapters.length} chapters imported`)
+    setTimeout(() => setToast(null), 3000)
+  }, [importChapters, workbook, triggerStorySoFarUpdate])
+
   const setValueAsync = useCallback(
     async (p: string, s: string, content: string, chapterIndex?: number) => {
       workbook.setValue(p, s, content, chapterIndex)
@@ -211,7 +276,7 @@ export default function WritingNotebookPage() {
   const hasChapterContent = (() => {
     const meta = workbook.getChapterMeta('writing')
     return Array.from({ length: meta.count }, (_, i) =>
-      workbook.getValue('writing', 'chapter', i)
+      workbook.getActiveDraftContent(i)
     ).some(c => c.trim())
   })()
 
@@ -242,6 +307,7 @@ export default function WritingNotebookPage() {
         lastSavedAt={lastSavedAt}
         bookId={bookId}
         onAddChapter={handleAddChapter}
+        onFileImport={handleFileImport}
       />
 
       {/* ═══ DESKTOP LAYOUT ════════════════════════════════════════ */}
@@ -250,6 +316,7 @@ export default function WritingNotebookPage() {
         <SidebarNav
           workbookData={workbook.data}
           getChapterMeta={workbook.getChapterMeta}
+          getChapterDraftMeta={workbook.getChapterDraftMeta}
           activeNavItem={activeNavItem}
           onNavChange={handleNavChange}
           onAddChapter={handleAddChapter}
@@ -283,6 +350,11 @@ export default function WritingNotebookPage() {
               setChapterMeta={workbook.setChapterMeta}
               getStyleGuide={workbook.getStyleGuide}
               setStyleGuide={workbook.setStyleGuide}
+              getChapterDraftMeta={workbook.getChapterDraftMeta}
+              setChapterDraftMeta={workbook.setChapterDraftMeta}
+              getChapterDraft={workbook.getChapterDraft}
+              setChapterDraft={workbook.setChapterDraft}
+              getActiveDraftContent={workbook.getActiveDraftContent}
               onWordCountChange={setWordCount}
               onKeystroke={resetIdleTimer}
               onStorySoFarUpdate={triggerStorySoFarUpdate}
@@ -344,6 +416,17 @@ export default function WritingNotebookPage() {
       </div>
 
       <MobileBottomBar activeTab={mobileTab} onTabChange={setMobileTab} />
+
+      {/* ── Import preview modal ────────────────────────────────────── */}
+      {importChapters && (
+        <ImportPreviewModal
+          chapters={importChapters}
+          getChapterDraftMeta={workbook.getChapterDraftMeta}
+          existingChapterCount={workbook.getChapterMeta('writing').count}
+          onConfirm={handleImportConfirm}
+          onCancel={() => setImportChapters(null)}
+        />
+      )}
 
       {/* ── Story So Far toast ─────────────────────────────────────── */}
       {toast && (

--- a/app/dashboard/writing-notebook/useWorkbook.ts
+++ b/app/dashboard/writing-notebook/useWorkbook.ts
@@ -20,6 +20,11 @@ export interface StyleGuide {
   aiRules?: { antiSlopEnabled: boolean; writingFormulaEnabled: boolean }
 }
 
+export interface ChapterDraftMeta {
+  draftCount: number
+  activeDraft: number
+}
+
 export interface WorkbookData {
   [key: string]: string
 }
@@ -131,9 +136,50 @@ export function useWorkbook(bookId: string | null) {
     setValue(phase, 'chapterMeta', JSON.stringify(meta))
   }, [setValue])
 
+  // ── Draft versioning helpers ───────────────────────────────────────────────
+
+  const getChapterDraftMeta = useCallback((chapterIndex: number): ChapterDraftMeta => {
+    const raw = data['writing:chapterDraftMeta']
+    if (!raw) return { draftCount: 1, activeDraft: 0 }
+    try {
+      const all = JSON.parse(raw) as Record<string, ChapterDraftMeta>
+      return all[String(chapterIndex)] ?? { draftCount: 1, activeDraft: 0 }
+    } catch { return { draftCount: 1, activeDraft: 0 } }
+  }, [data])
+
+  const setChapterDraftMeta = useCallback((chapterIndex: number, meta: ChapterDraftMeta) => {
+    const raw = data['writing:chapterDraftMeta']
+    let all: Record<string, ChapterDraftMeta> = {}
+    if (raw) { try { all = JSON.parse(raw) } catch { /* noop */ } }
+    all[String(chapterIndex)] = meta
+    setValue('writing', 'chapterDraftMeta', JSON.stringify(all))
+  }, [data, setValue])
+
+  const getChapterDraft = useCallback((chapterIndex: number, draftIndex: number): string => {
+    // New format first
+    const draftKey = `writing:chapter:${chapterIndex}:draft:${draftIndex}`
+    if (data[draftKey] != null) return data[draftKey]
+    // Fallback to old format for draft 0
+    if (draftIndex === 0) return data[`writing:chapter:${chapterIndex}`] ?? ''
+    return ''
+  }, [data])
+
+  const setChapterDraft = useCallback((chapterIndex: number, draftIndex: number, content: string) => {
+    // Always write to new draft key format
+    // We store as writing:chapter:{N}:draft:{D} — phase=writing, section=chapter:{N}:draft:{D}
+    setValue('writing', `chapter:${chapterIndex}:draft:${draftIndex}`, content)
+  }, [setValue])
+
+  const getActiveDraftContent = useCallback((chapterIndex: number): string => {
+    const meta = getChapterDraftMeta(chapterIndex)
+    return getChapterDraft(chapterIndex, meta.activeDraft)
+  }, [getChapterDraftMeta, getChapterDraft])
+
   return {
     data, loaded, getValue, setValue, isSaving, isSaved,
     saving, saved,
     getStyleGuide, setStyleGuide, getChapterMeta, setChapterMeta, load,
+    getChapterDraftMeta, setChapterDraftMeta,
+    getChapterDraft, setChapterDraft, getActiveDraftContent,
   }
 }

--- a/app/writing-notebook/page.tsx
+++ b/app/writing-notebook/page.tsx
@@ -4,12 +4,14 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useBooks } from '@/hooks/useBooks'
 import { useWorkbook } from '@/app/dashboard/writing-notebook/useWorkbook'
+import { parseManuscriptIntoChapters, type ParsedChapter } from '@/lib/parseManuscript'
 
 // ── Desktop components (new layout) ──────────────────────────────────
 import { WritingNotebookTopBar } from '@/components/writing-notebook/WritingNotebookTopBar'
 import { SidebarNav } from '@/components/writing-notebook/SidebarNav'
 import { InlineAIPanel } from '@/components/writing-notebook/InlineAIPanel'
 import { EditorArea } from '@/components/writing-notebook/EditorArea'
+import { ImportPreviewModal } from '@/components/writing-notebook/ImportPreviewModal'
 
 // ── Mobile components ─────────────────────────────────────────────────
 import { NotebookPane } from '@/components/writing-notebook/NotebookPane'
@@ -38,6 +40,9 @@ export default function WritingNotebookPage() {
   const [storySoFarStatus, setStorySoFarStatus] = useState<'upToDate' | 'updating'>('upToDate')
   const [toast, setToast] = useState<string | null>(null)
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null)
+
+  // ── Import state ───────────────────────────────────────────────────
+  const [importChapters, setImportChapters] = useState<ParsedChapter[] | null>(null)
 
   // ── Mobile state ───────────────────────────────────────────────────
   const [phase, setPhase] = useState<NotebookPhase>('setup')
@@ -85,7 +90,7 @@ export default function WritingNotebookPage() {
     const meta = workbook.getChapterMeta('writing')
     const chapters = Array.from({ length: meta.count }, (_, i) => ({
       title: meta.titles[i] ?? '',
-      content: workbook.getValue('writing', 'chapter', i),
+      content: workbook.getActiveDraftContent(i),
       order: i,
     })).filter(c => c.content.trim())
     if (!chapters.length) return
@@ -113,7 +118,7 @@ export default function WritingNotebookPage() {
     if (workbook.getValue('writing', 'storySoFar').trim()) return
     const meta = workbook.getChapterMeta('writing')
     const hasContent = Array.from({ length: meta.count }, (_, i) =>
-      workbook.getValue('writing', 'chapter', i)
+      workbook.getActiveDraftContent(i)
     ).some(c => c.trim())
     if (hasContent) {
       didLoadTriggerRef.current = true
@@ -169,6 +174,54 @@ export default function WritingNotebookPage() {
     workbook.setValue('writing', 'chapter', content, chapterIndex)
   }, [workbook])
 
+  // ── Manuscript import flow ─────────────────────────────────────────
+  const handleFileImport = useCallback((file: File) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const text = reader.result as string
+      const parsed = parseManuscriptIntoChapters(text)
+      if (parsed.length === 0) {
+        setToast('Could not detect chapters — make sure your file uses # Chapter headers')
+        setTimeout(() => setToast(null), 4000)
+        return
+      }
+      setImportChapters(parsed)
+    }
+    reader.readAsText(file)
+  }, [])
+
+  const handleImportConfirm = useCallback(() => {
+    if (!importChapters) return
+    const meta = workbook.getChapterMeta('writing')
+    for (const ch of importChapters) {
+      const idx = ch.chapterNumber - 1
+      const existing = workbook.getChapterDraftMeta(idx)
+      const newDraftIdx = existing.draftCount
+      workbook.setChapterDraft(idx, newDraftIdx, ch.content)
+      workbook.setChapterDraftMeta(idx, { draftCount: newDraftIdx + 1, activeDraft: newDraftIdx })
+      if (ch.title && !(meta.titles[idx]?.trim())) {
+        const titles = [...meta.titles]
+        while (titles.length <= idx) titles.push('')
+        titles[idx] = ch.title
+        workbook.setChapterMeta('writing', { ...workbook.getChapterMeta('writing'), titles })
+      }
+    }
+    const maxImportIdx = Math.max(...importChapters.map(c => c.chapterNumber - 1))
+    if (maxImportIdx >= meta.count) {
+      const titles = [...workbook.getChapterMeta('writing').titles]
+      while (titles.length <= maxImportIdx) titles.push('')
+      for (const ch of importChapters) {
+        if (ch.chapterNumber - 1 >= meta.count && ch.title) titles[ch.chapterNumber - 1] = ch.title
+      }
+      workbook.setChapterMeta('writing', { count: maxImportIdx + 1, titles })
+    }
+    setImportChapters(null)
+    setActiveNavItem('chapter:0')
+    triggerStorySoFarUpdate()
+    setToast(`${importChapters.length} chapters imported`)
+    setTimeout(() => setToast(null), 3000)
+  }, [importChapters, workbook, triggerStorySoFarUpdate])
+
   const setValueAsync = useCallback(
     async (p: string, s: string, content: string, chapterIndex?: number) => {
       workbook.setValue(p, s, content, chapterIndex)
@@ -182,7 +235,7 @@ export default function WritingNotebookPage() {
   const hasChapterContent = (() => {
     const meta = workbook.getChapterMeta('writing')
     return Array.from({ length: meta.count }, (_, i) =>
-      workbook.getValue('writing', 'chapter', i)
+      workbook.getActiveDraftContent(i)
     ).some(c => c.trim())
   })()
 
@@ -198,6 +251,7 @@ export default function WritingNotebookPage() {
         lastSavedAt={lastSavedAt}
         bookId={bookId}
         onAddChapter={handleAddChapter}
+        onFileImport={handleFileImport}
       />
 
       {/* ═══ DESKTOP LAYOUT ════════════════════════════════════════ */}
@@ -206,6 +260,7 @@ export default function WritingNotebookPage() {
         <SidebarNav
           workbookData={workbook.data}
           getChapterMeta={workbook.getChapterMeta}
+          getChapterDraftMeta={workbook.getChapterDraftMeta}
           activeNavItem={activeNavItem}
           onNavChange={handleNavChange}
           onAddChapter={handleAddChapter}
@@ -237,6 +292,11 @@ export default function WritingNotebookPage() {
               setChapterMeta={workbook.setChapterMeta}
               getStyleGuide={workbook.getStyleGuide}
               setStyleGuide={workbook.setStyleGuide}
+              getChapterDraftMeta={workbook.getChapterDraftMeta}
+              setChapterDraftMeta={workbook.setChapterDraftMeta}
+              getChapterDraft={workbook.getChapterDraft}
+              setChapterDraft={workbook.setChapterDraft}
+              getActiveDraftContent={workbook.getActiveDraftContent}
               onWordCountChange={setWordCount}
               onKeystroke={resetIdleTimer}
               onStorySoFarUpdate={triggerStorySoFarUpdate}
@@ -306,6 +366,17 @@ export default function WritingNotebookPage() {
       </div>
 
       <MobileBottomBar activeTab={mobileTab} onTabChange={setMobileTab} />
+
+      {/* Import preview modal */}
+      {importChapters && (
+        <ImportPreviewModal
+          chapters={importChapters}
+          getChapterDraftMeta={workbook.getChapterDraftMeta}
+          existingChapterCount={workbook.getChapterMeta('writing').count}
+          onConfirm={handleImportConfirm}
+          onCancel={() => setImportChapters(null)}
+        />
+      )}
 
       {/* Story So Far toast */}
       {toast && (

--- a/components/writing-notebook/EditorArea.tsx
+++ b/components/writing-notebook/EditorArea.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { Bold, Italic, Underline, Heading1, Heading2, Quote, List, Undo2, Redo2, Plus, X } from 'lucide-react'
-import type { ChapterMeta, StyleGuide, WorkbookData } from '@/app/dashboard/writing-notebook/useWorkbook'
+import type { ChapterMeta, ChapterDraftMeta, StyleGuide, WorkbookData } from '@/app/dashboard/writing-notebook/useWorkbook'
 import { ExportDropdown } from './ExportDropdown'
 
 interface Props {
@@ -14,6 +14,11 @@ interface Props {
   setChapterMeta: (phase: 'writing' | 'polish', meta: ChapterMeta) => void
   getStyleGuide: () => StyleGuide
   setStyleGuide: (guide: StyleGuide) => void
+  getChapterDraftMeta: (chapterIndex: number) => ChapterDraftMeta
+  setChapterDraftMeta: (chapterIndex: number, meta: ChapterDraftMeta) => void
+  getChapterDraft: (chapterIndex: number, draftIndex: number) => string
+  setChapterDraft: (chapterIndex: number, draftIndex: number, content: string) => void
+  getActiveDraftContent: (chapterIndex: number) => string
   onWordCountChange: (count: number) => void
   onKeystroke: () => void
   onStorySoFarUpdate?: () => void
@@ -273,6 +278,8 @@ export function EditorArea({
   activeNavItem, bookId, workbookData,
   getValue, setValue, getChapterMeta, setChapterMeta,
   getStyleGuide, setStyleGuide,
+  getChapterDraftMeta, setChapterDraftMeta,
+  getChapterDraft, setChapterDraft, getActiveDraftContent,
   onWordCountChange, onKeystroke,
   onStorySoFarUpdate, storySoFarStatus, hasChapterContent,
 }: Props) {
@@ -282,8 +289,16 @@ export function EditorArea({
   const isChapter = activeNavItem.startsWith('chapter:')
   const chapterIdx = isChapter ? parseInt(activeNavItem.split(':')[1]) : null
 
+  // Draft state for chapters
+  const draftMeta = isChapter && chapterIdx != null ? getChapterDraftMeta(chapterIdx) : null
+  const activeDraftIdx = draftMeta?.activeDraft ?? 0
+  const draftCount = draftMeta?.draftCount ?? 1
+
+  // New-draft inline choice state
+  const [showNewDraftChoice, setShowNewDraftChoice] = useState(false)
+
   const getInitialContent = useCallback((): string => {
-    if (isChapter && chapterIdx != null) return getValue('writing', 'chapter', chapterIdx)
+    if (isChapter && chapterIdx != null) return getActiveDraftContent(chapterIdx)
     switch (activeNavItem) {
       case 'storyOutline': return getValue('setup', 'storyOutline')
       case 'styleGuide':   return getValue('setup', 'styleGuide')
@@ -291,13 +306,14 @@ export function EditorArea({
       case 'storySoFar':   return getValue('writing', 'storySoFar')
       default: return ''
     }
-  }, [activeNavItem, isChapter, chapterIdx, getValue])
+  }, [activeNavItem, isChapter, chapterIdx, getValue, getActiveDraftContent])
 
   const [content, setContent] = useState(getInitialContent)
 
   // Reset content when nav item changes
   useEffect(() => {
     setContent(getInitialContent())
+    setShowNewDraftChoice(false)
   }, [activeNavItem, getInitialContent]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Update live word count
@@ -309,7 +325,8 @@ export function EditorArea({
     setContent(v)
     onKeystroke()
     if (isChapter && chapterIdx != null) {
-      setValue('writing', 'chapter', v, chapterIdx)
+      // Always save to active draft
+      setChapterDraft(chapterIdx, activeDraftIdx, v)
     } else {
       switch (activeNavItem) {
         case 'storyOutline': setValue('setup', 'storyOutline', v); break
@@ -318,6 +335,31 @@ export function EditorArea({
         case 'storySoFar':   setValue('writing', 'storySoFar', v); break
       }
     }
+  }
+
+  // Switch to a different draft
+  function handleDraftSwitch(draftIdx: number) {
+    if (chapterIdx == null || draftIdx === activeDraftIdx) return
+    // Save current content first
+    setChapterDraft(chapterIdx, activeDraftIdx, content)
+    // Switch active draft
+    setChapterDraftMeta(chapterIdx, { draftCount, activeDraft: draftIdx })
+    // Load new draft content
+    setContent(getChapterDraft(chapterIdx, draftIdx))
+    setShowNewDraftChoice(false)
+  }
+
+  // Create a new draft
+  function handleNewDraft(copyContent: boolean) {
+    if (chapterIdx == null) return
+    // Save current content first
+    setChapterDraft(chapterIdx, activeDraftIdx, content)
+    const newIdx = draftCount
+    const newContent = copyContent ? content : ''
+    setChapterDraft(chapterIdx, newIdx, newContent)
+    setChapterDraftMeta(chapterIdx, { draftCount: draftCount + 1, activeDraft: newIdx })
+    setContent(newContent)
+    setShowNewDraftChoice(false)
   }
 
   // Update chapter title in chapterMeta
@@ -425,6 +467,61 @@ export function EditorArea({
         <FormattingToolbar textareaRef={textareaRef} onUpdate={handleContentChange} />
         <div className="flex-1 overflow-y-auto">
           <div className="px-8 py-6 max-w-3xl mx-auto">
+            {/* Draft switcher row — show if draftCount > 1 */}
+            {draftCount > 1 && (
+              <div className="flex items-center gap-1.5 mb-3 relative">
+                {Array.from({ length: draftCount }, (_, i) => (
+                  <button
+                    key={i}
+                    onClick={() => handleDraftSwitch(i)}
+                    className="px-3 py-1 rounded-full transition-colors"
+                    style={{
+                      fontSize: 12,
+                      fontWeight: 500,
+                      background: i === activeDraftIdx ? '#E9A020' : 'transparent',
+                      color: i === activeDraftIdx ? '#FFFFFF' : '#888888',
+                    }}
+                    onMouseEnter={e => {
+                      if (i !== activeDraftIdx) (e.target as HTMLElement).style.background = '#FFF8F0'
+                    }}
+                    onMouseLeave={e => {
+                      if (i !== activeDraftIdx) (e.target as HTMLElement).style.background = 'transparent'
+                    }}
+                  >
+                    Draft {i + 1}
+                  </button>
+                ))}
+                <button
+                  onClick={() => setShowNewDraftChoice(v => !v)}
+                  className="px-2 py-1 text-[12px] font-medium transition-opacity hover:opacity-70"
+                  style={{ color: '#E9A020', background: 'none', border: 'none' }}
+                >
+                  + New draft
+                </button>
+                {showNewDraftChoice && (
+                  <div
+                    className="absolute top-full left-0 mt-1 flex gap-1.5 px-2 py-1.5 rounded-lg z-10"
+                    style={{ background: '#FFFFFF', border: '0.5px solid #E5E7EB', boxShadow: '0 2px 8px rgba(0,0,0,0.08)' }}
+                  >
+                    <button
+                      onClick={() => handleNewDraft(false)}
+                      className="px-3 py-1 rounded-md text-[12px] font-medium transition-colors hover:bg-gray-50"
+                      style={{ color: '#1E2D3D', border: '0.5px solid #E5E7EB' }}
+                    >
+                      Start blank
+                    </button>
+                    <button
+                      onClick={() => handleNewDraft(true)}
+                      className="px-3 py-1 rounded-md text-[12px] font-medium transition-colors hover:bg-gray-50"
+                      style={{ color: '#1E2D3D', border: '0.5px solid #E5E7EB' }}
+                    >
+                      Copy current draft
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+
             {/* Chapter label pills */}
             <div className="flex items-center gap-2 mb-4">
               <span
@@ -439,6 +536,39 @@ export function EditorArea({
               >
                 {status}
               </span>
+              {/* "+ New draft" button when only 1 draft exists */}
+              {draftCount <= 1 && (
+                <div className="relative ml-auto">
+                  <button
+                    onClick={() => setShowNewDraftChoice(v => !v)}
+                    className="px-2 py-1 text-[12px] font-medium transition-opacity hover:opacity-70"
+                    style={{ color: '#E9A020', background: 'none', border: 'none' }}
+                  >
+                    + New draft
+                  </button>
+                  {showNewDraftChoice && (
+                    <div
+                      className="absolute top-full right-0 mt-1 flex gap-1.5 px-2 py-1.5 rounded-lg z-10"
+                      style={{ background: '#FFFFFF', border: '0.5px solid #E5E7EB', boxShadow: '0 2px 8px rgba(0,0,0,0.08)' }}
+                    >
+                      <button
+                        onClick={() => handleNewDraft(false)}
+                        className="px-3 py-1 rounded-md text-[12px] font-medium transition-colors hover:bg-gray-50"
+                        style={{ color: '#1E2D3D', border: '0.5px solid #E5E7EB' }}
+                      >
+                        Start blank
+                      </button>
+                      <button
+                        onClick={() => handleNewDraft(true)}
+                        className="px-3 py-1 rounded-md text-[12px] font-medium transition-colors hover:bg-gray-50"
+                        style={{ color: '#1E2D3D', border: '0.5px solid #E5E7EB' }}
+                      >
+                        Copy current draft
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             {/* Editable chapter title */}

--- a/components/writing-notebook/ImportPreviewModal.tsx
+++ b/components/writing-notebook/ImportPreviewModal.tsx
@@ -1,0 +1,122 @@
+'use client'
+import { X } from 'lucide-react'
+import type { ParsedChapter } from '@/lib/parseManuscript'
+import type { ChapterDraftMeta } from '@/app/dashboard/writing-notebook/useWorkbook'
+
+interface Props {
+  chapters: ParsedChapter[]
+  getChapterDraftMeta: (chapterIndex: number) => ChapterDraftMeta
+  existingChapterCount: number
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+function wordCount(text: string): number {
+  return text.trim() ? text.trim().split(/\s+/).length : 0
+}
+
+export function ImportPreviewModal({
+  chapters, getChapterDraftMeta, existingChapterCount, onConfirm, onCancel,
+}: Props) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: 'rgba(30,45,61,0.5)' }}
+      onClick={onCancel}
+    >
+      <div
+        className="relative flex flex-col"
+        style={{
+          background: '#FFFFFF',
+          border: '0.5px solid #e8e0d8',
+          borderRadius: 12,
+          maxWidth: 480,
+          width: '90vw',
+          padding: 24,
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Close button */}
+        <button
+          onClick={onCancel}
+          className="absolute top-3 right-3 w-7 h-7 flex items-center justify-center rounded-full transition-colors hover:bg-gray-100"
+          style={{ color: '#9CA3AF' }}
+        >
+          <X size={14} />
+        </button>
+
+        {/* Header */}
+        <h3 className="text-[16px] font-medium mb-0.5" style={{ color: '#1E2D3D' }}>
+          Import manuscript
+        </h3>
+        <p className="text-[13px] mb-4" style={{ color: '#9CA3AF' }}>
+          {chapters.length} chapter{chapters.length !== 1 ? 's' : ''} detected
+        </p>
+
+        {/* Chapter list */}
+        <div
+          className="flex flex-col gap-2 overflow-y-auto mb-5"
+          style={{ maxHeight: 260 }}
+        >
+          {chapters.map(ch => {
+            const idx = ch.chapterNumber - 1
+            const isNew = idx >= existingChapterCount
+            const existingMeta = !isNew ? getChapterDraftMeta(idx) : null
+            const draftLabel = isNew
+              ? 'New — Draft 1'
+              : `Adding as Draft ${(existingMeta?.draftCount ?? 1) + 1}`
+            const wc = wordCount(ch.content)
+
+            return (
+              <div
+                key={ch.chapterNumber}
+                className="flex items-center gap-2 px-3 py-2 rounded-lg"
+                style={{ background: '#FAFAF9', border: '0.5px solid #F0EDE8' }}
+              >
+                <span
+                  className="px-2 py-0.5 rounded-full text-[10px] font-semibold shrink-0"
+                  style={{ background: '#F97B6B', color: '#FFFFFF' }}
+                >
+                  Ch {ch.chapterNumber}
+                </span>
+                <span className="text-[13px] flex-1 truncate min-w-0" style={{ color: '#1E2D3D' }}>
+                  {ch.title || 'Untitled'}
+                </span>
+                <span
+                  className="px-2 py-0.5 rounded-full text-[10px] font-medium shrink-0 whitespace-nowrap"
+                  style={isNew
+                    ? { background: '#D6F0E0', color: '#1A6B3A' }
+                    : { background: '#FFF3E0', color: '#E9A020' }
+                  }
+                >
+                  {draftLabel}
+                </span>
+                <span className="text-[11px] shrink-0" style={{ color: '#9CA3AF' }}>
+                  {wc.toLocaleString()} w
+                </span>
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium transition-colors hover:bg-gray-50"
+            style={{ color: '#6B7280' }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 rounded-lg text-[13px] font-medium transition-colors"
+            style={{ background: '#E9A020', color: '#FFFFFF' }}
+          >
+            Import {chapters.length} chapter{chapters.length !== 1 ? 's' : ''}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/writing-notebook/SidebarNav.tsx
+++ b/components/writing-notebook/SidebarNav.tsx
@@ -1,12 +1,13 @@
 'use client'
 import { Plus } from 'lucide-react'
-import type { WorkbookData, ChapterMeta } from '@/app/dashboard/writing-notebook/useWorkbook'
+import type { WorkbookData, ChapterMeta, ChapterDraftMeta } from '@/app/dashboard/writing-notebook/useWorkbook'
 
 export type StorySoFarStatus = 'upToDate' | 'updating'
 
 interface Props {
   workbookData: WorkbookData
   getChapterMeta: (phase: 'writing' | 'polish') => ChapterMeta
+  getChapterDraftMeta: (chapterIndex: number) => ChapterDraftMeta
   activeNavItem: string
   onNavChange: (item: string) => void
   onAddChapter: () => void
@@ -76,7 +77,7 @@ function SectionLabel({ children }: { children: string }) {
 }
 
 export function SidebarNav({
-  workbookData, getChapterMeta, activeNavItem, onNavChange, onAddChapter, storySoFarStatus,
+  workbookData, getChapterMeta, getChapterDraftMeta, activeNavItem, onNavChange, onAddChapter, storySoFarStatus,
   onStorySoFarUpdate, hasChapterContent,
 }: Props) {
   const writingMeta = getChapterMeta('writing')
@@ -148,6 +149,7 @@ export function SidebarNav({
           const title = writingMeta.titles[idx] ?? ''
           const status = getChapterStatus(idx, workbookData)
           const dotColor = BOOK_COLORS[idx % BOOK_COLORS.length]
+          const chDraftMeta = getChapterDraftMeta(idx)
 
           return (
             <button
@@ -167,6 +169,11 @@ export function SidebarNav({
               <span className="text-[13px] flex-1 truncate min-w-0">
                 Ch {idx + 1}{title ? ` · ${title}` : ''}
               </span>
+              {chDraftMeta.draftCount > 1 && (
+                <span className="text-[10px] shrink-0" style={{ color: '#9CA3AF' }}>
+                  {chDraftMeta.draftCount} drafts
+                </span>
+              )}
               <span
                 className="text-[10px] px-1.5 py-0.5 rounded-full shrink-0"
                 style={STATUS_PILL[status]}

--- a/components/writing-notebook/WritingNotebookTopBar.tsx
+++ b/components/writing-notebook/WritingNotebookTopBar.tsx
@@ -1,7 +1,7 @@
 'use client'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
-import { ChevronLeft, Plus } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { ChevronLeft, Plus, Upload } from 'lucide-react'
 import { BookDropdown } from './BookDropdown'
 import { ExportDropdown } from './ExportDropdown'
 import type { BookRecord } from '@/hooks/useBooks'
@@ -16,6 +16,7 @@ interface Props {
   lastSavedAt: Date | null
   bookId: string
   onAddChapter: () => void
+  onFileImport?: (file: File) => void
 }
 
 // ── Save status indicator ──────────────────────────────────────────────────
@@ -82,13 +83,31 @@ function SaveStatusIndicator({
 export function WritingNotebookTopBar({
   books, selectedBookId, onBookChange, onNewBook,
   wordCount, saving, lastSavedAt,
-  bookId, onAddChapter,
+  bookId, onAddChapter, onFileImport,
 }: Props) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (file && onFileImport) onFileImport(file)
+    // Reset so same file can be re-selected
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
   return (
     <div
       className="h-12 flex items-center px-4 shrink-0 gap-4"
       style={{ background: '#FFFFFF', borderBottom: '0.5px solid #E5E7EB' }}
     >
+      {/* Hidden file input — always in DOM */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".txt,.md"
+        onChange={handleFileSelect}
+        style={{ display: 'none' }}
+      />
+
       {/* ── Left ─────────────────────────────── */}
       <div className="flex items-center gap-3 min-w-0" style={{ flex: '0 0 auto' }}>
         <Link
@@ -122,6 +141,16 @@ export function WritingNotebookTopBar({
             {wordCount.toLocaleString()} words
           </span>
         )}
+
+        {/* Import button */}
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[13px] font-medium transition-colors hover:opacity-80"
+          style={{ color: '#6B7280', border: '0.5px solid #E5E7EB' }}
+        >
+          <Upload size={13} />
+          Import
+        </button>
 
         <ExportDropdown bookId={bookId} drawerToggle="drafts" />
 

--- a/lib/parseManuscript.ts
+++ b/lib/parseManuscript.ts
@@ -1,0 +1,103 @@
+export interface ParsedChapter {
+  chapterNumber: number
+  title: string
+  pov: string
+  content: string
+}
+
+const CHAPTER_HEADER = /^#{1,2}\s+Chapter\s+\d+/i
+const BARE_CHAPTER = /^Chapter\s+\d+/i
+const HR = /^---+$/
+
+const STRIP_PATTERNS = [
+  /^#{1,4}\s+/, // markdown headers
+  /^\*?(Revised|Draft|Edited|Opening hook|Summary|Closing cliffhanger):/i,
+  /^---+$/,
+  /^###\s+(Stillwater|Book)/i, // series/book title lines
+]
+
+function isChapterStart(line: string): boolean {
+  return CHAPTER_HEADER.test(line) || BARE_CHAPTER.test(line)
+}
+
+function extractTitle(lines: string[]): string {
+  // Look for a subtitle/location line after the header — skip date/POV lines
+  for (let i = 0; i < Math.min(5, lines.length); i++) {
+    const line = lines[i].trim()
+    if (!line) continue
+    if (/^#{1,2}\s+Chapter/i.test(line)) continue
+    if (/^Chapter\s+\d+/i.test(line)) continue
+    if (/POV/i.test(line)) continue
+    if (/^\d{4}|^(January|February|March|April|May|June|July|August|September|October|November|December)/i.test(line)) continue
+    if (/^---+$/.test(line)) continue
+    // Strip markdown heading prefix if present
+    const cleaned = line.replace(/^#{1,4}\s+/, '').trim()
+    if (cleaned) return cleaned
+  }
+  return ''
+}
+
+function extractPov(lines: string[]): string {
+  for (let i = 0; i < Math.min(8, lines.length); i++) {
+    const line = lines[i].trim()
+    if (/POV/i.test(line) || /·\s+\w+'s\s+POV/i.test(line)) {
+      return line.replace(/^#{1,4}\s+/, '').trim()
+    }
+  }
+  return ''
+}
+
+function shouldStripLine(line: string): boolean {
+  return STRIP_PATTERNS.some(p => p.test(line.trim()))
+}
+
+export function parseManuscriptIntoChapters(text: string): ParsedChapter[] {
+  const lines = text.split('\n')
+  const chapterStarts: number[] = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (isChapterStart(line)) {
+      chapterStarts.push(i)
+      continue
+    }
+    // HR followed within 3 lines by a chapter header
+    if (HR.test(line)) {
+      for (let j = i + 1; j <= Math.min(i + 3, lines.length - 1); j++) {
+        if (isChapterStart(lines[j].trim())) {
+          chapterStarts.push(j)
+          break
+        }
+      }
+    }
+  }
+
+  // Deduplicate (an HR detection might find the same header)
+  const uniqueStarts = Array.from(new Set(chapterStarts)).sort((a, b) => a - b)
+
+  if (uniqueStarts.length === 0) return []
+
+  const chapters: ParsedChapter[] = []
+
+  for (let c = 0; c < uniqueStarts.length; c++) {
+    const start = uniqueStarts[c]
+    const end = c + 1 < uniqueStarts.length ? uniqueStarts[c + 1] : lines.length
+    const chapterLines = lines.slice(start, end)
+
+    const title = extractTitle(chapterLines)
+    const pov = extractPov(chapterLines)
+
+    // Build content — strip header/metadata lines, keep prose
+    const contentLines = chapterLines.filter(l => !shouldStripLine(l))
+    const content = contentLines.join('\n').trim()
+
+    chapters.push({
+      chapterNumber: c + 1,
+      title,
+      pov,
+      content,
+    })
+  }
+
+  return chapters
+}


### PR DESCRIPTION
## Summary
- Multi-draft per chapter with backward-compatible data structure (`writing:chapter:N:draft:D` keys, falls back to old `writing:chapter:N` for draft 0)
- Draft switcher pill row in editor with "+ New draft" (blank or copy current)
- Manuscript import flow: `.txt`/`.md` file upload → chapter parser → preview modal → imports as new drafts (never overwrites)
- Sidebar shows draft count badges per chapter
- Story So Far generation reads from active draft content
- Golden rules enforced: drafts never deleted, imports never overwrite, switching always saves current content first

## Test plan
- [ ] Open Writing Notebook, navigate to a chapter — verify content loads normally (backward compat)
- [ ] Click "+ New draft" on a chapter, choose "Start blank" — verify empty draft created, pill row appears
- [ ] Switch between drafts — verify content saves before switching, correct content loads
- [ ] Create a draft via "Copy current draft" — verify content is duplicated
- [ ] Click Import button, upload a `.txt` file with `# Chapter` headers — verify preview modal shows detected chapters
- [ ] Confirm import — verify chapters imported as new drafts, sidebar shows draft count badges
- [ ] Upload a file with no chapter headers — verify error toast appears
- [ ] Trigger Story So Far update — verify it uses active draft content
- [ ] Verify `npx tsc --noEmit` passes clean
